### PR TITLE
fix(rsyslog.yaml): Do not allow others to read falco log file

### DIFF
--- a/tasks/rsyslog.yml
+++ b/tasks/rsyslog.yml
@@ -34,7 +34,7 @@
   file:
     dest: "{{ falco_syslog_target }}"
     state: touch
-    mode: '0644'
+    mode: '0640'
     owner: "{{ syslog_user }}"
     group: root
   when:


### PR DESCRIPTION
While the rule file perms are correctly set to be quite strict, it might also make sense to change log file perm from 0644 to 0640 so that it wouldn't be world-readable as it could provide hints for the attacker, so unless there is no good reason to keep it world-readable, I'd propose to make this change.