### PR TITLE
Adds variables for Ubuntu 23.04

### DIFF
--- a/vars/Ubuntu-23.04.yml
+++ b/vars/Ubuntu-23.04.yml
@@ -1,0 +1,8 @@
+---
+
+falco_pkgs:
+    - falco
+    - jq          # Slack output depends on jq
+    - mailutils   # Mail output depends on mailutils
+
+syslog_user: syslog


### PR DESCRIPTION
Adds the missing variables file for Ubuntu 23.04.

## Description
This is needed in order to support Ubuntu 23.04. The current version of the role fails for this version of OS due to the lack of this variables file.

## Motivation and Context
The role currently fails to set up Falco due to the missing vars file.
