### PR TITLE
fix: Make falcoctl tasks optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ falco_mode: modern-ebpf
 # falco_mode: bpf
 # falco_mode: kmod
 falco_k8s_helm: false
+falcoctl_enabled: true
 # required for reporting using jq
 falco_json_output: true
 falco_log_stderr: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,3 +22,4 @@
 
 - name: Import falcoctl
   ansible.builtin.import_tasks: falcoctl.yml
+  when: falcoctl_enabled | bool


### PR DESCRIPTION
## Description
This PR makes `falcoctl` tasks optional to be able to support cases where the pre-built kernel driver from The Falco Project is not available for download. These cases are now covered by `modern_ebpf` mode  that works out of the box, regardless of the kernel release

## Motivation and Context
On Rocky Linux I [encountered an issue](https://falco.org/docs/troubleshooting/start-up-error/#kernel-drivers) while running [falcoctl driver install](https://github.com/juju4/ansible-falco/blob/9c642a5f3b2ceed3ef76fdb516a4e1a9d9afb06c/tasks/falcoctl.yml#L20). This is due to the fact the pre-built kernel driver from The Falco Project is not available for download.
```
[root@ip-172-23-192-159 rocky]# falcoctl driver install
2025-02-17 11:04:11 INFO  Running falcoctl driver install
                      ├ driver version: 8.0.0+driver
                      ├ driver type: ebpf
                      ├ driver name: falco
                      ├ compile: true
                      ├ download: true
                      ├ target: rocky
                      ├ arch: x86_64
                      ├ kernel release: 5.14.0-503.14.1.el9_5.x86_64
                      └ kernel version: #1 SMP PREEMPT_DYNAMIC Fri Nov 15 12:04:32 UTC 2024
2025-02-17 11:04:11 INFO  Removing eBPF probe symlink path: /root/.falco/falco-bpf.o
2025-02-17 11:04:11 INFO  Trying to download a driver.
                      └ url: https://download.falco.org/driver/8.0.0%2Bdriver/x86_64/falco_rocky_5.14.0-503.14.1.el9_5.x86_64_1.o
2025-02-17 11:04:11 WARN  Non-200 response from url. code: 404
2025-02-17 11:04:11 WARN  unable to find a prebuilt driver
2025-02-17 11:04:11 INFO  Trying to compile the requested driver
2025-02-17 11:04:11 INFO  Trying automatic kernel headers download.
2025-02-17 11:04:13 WARN  Failed to generate script. err: kernel headers not found
2025-02-17 11:04:13 INFO  Trying to build eBPF probe.

```

According to [falco installation documentation](https://falco.org/docs/setup/tarball/#install) in case of `modern_ebpf`  :

> Use the falcoctl driver tool to configure Falco and install the kernel module or the eBPF probe. If you want to use other sources like the modern eBPF probe or plugins, you can skip this step.

## How Has This Been Tested?
Disabled `falcoctl` tasks locally and was able to have a successful run of the role. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed including pre-commit and github actions.
- [x] Used in production.

