### PR TITLE
Feature request: role execution with "become: true" #70

### DIFF
--- a/tasks/logrotate.yml
+++ b/tasks/logrotate.yml
@@ -12,6 +12,7 @@
     src: logrotate-falco.j2
     dest: /etc/logrotate.d/falco
     mode: '0644'
+    owner: root
+    group: root
     backup: yes
-    # logrotate error on ownership - https://github.com/ansible/ansible/issues/53516
-    # validate: 'logrotate -dv %s'
+    validate: 'logrotate -dv %s'


### PR DESCRIPTION
Add owner:group to templating task for /etc/falco/falco.yaml This fixes the validation error because of bad ownership.


## Description
Executing the role with become: true fails during the logrotate configuration validation. This is because the template task transfers the file as the unprivileged user, and the task specifies permissions but not an owner. As a result, the file is created at /etc/logrotate.d/falco but is still owned by the user. This causes the playbook to fail within the become: true context.

## Motivation and Context
Make the role usable with become
[Issue #70 ](https://github.com/juju4/ansible-falco/issues/70)

## How Has This Been Tested?
gitlab actions

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed including pre-commit and github actions.
- [x] Used in production.

<!--
https://www.talater.com/open-source-templates/#/page/1
-->
